### PR TITLE
Extends parsing MetaData by adding a TwitterCardParser

### DIFF
--- a/lib/src/metadata_fetch_base.dart
+++ b/lib/src/metadata_fetch_base.dart
@@ -14,18 +14,19 @@ Future<Metadata> extract(String url) async {
   }
 
   /// Sane defaults; Always return the Domain name as the [title], and a [description] for a given [url]
-  var default_output = Metadata();
+  final default_output = Metadata();
   default_output.title = getDomain(url);
   default_output.description = url;
 
   // Make our network call
-  var response = await http.get(url);
-  var document = responseToDocument(response);
+  final response = await http.get(url);
+  final document = responseToDocument(response);
 
   if (document == null) {
     return default_output;
   }
-  var data = _extractMetadata(document);
+
+  final data = _extractMetadata(document);
   if (data == null) {
     return default_output;
   }
@@ -42,6 +43,7 @@ Document responseToDocument(http.Response response) {
   Document document;
   try {
     document = parser.parse(utf8.decode(response.bodyBytes));
+    document.requestUrl = response.request.url.toString();
   } catch (err) {
     return document;
   }

--- a/lib/src/parsers/base_parser.dart
+++ b/lib/src/parsers/base_parser.dart
@@ -3,12 +3,15 @@ abstract class BaseMetadataParser {
   String title;
   String description;
   String image;
+  String url;
 
   Metadata parse() {
     var m = Metadata();
     m.title = title;
     m.description = description;
     m.image = image;
+    m.url = url;
+
     return m;
   }
 
@@ -17,6 +20,7 @@ abstract class BaseMetadataParser {
       'title': title,
       'description': description,
       'image': image,
+      'url': url,
     };
   }
 

--- a/lib/src/parsers/htmlmeta_parser.dart
+++ b/lib/src/parsers/htmlmeta_parser.dart
@@ -12,7 +12,9 @@ class HtmlMetaParser extends BaseMetadataParser {
 
   /// Get the [Metadata.title] from the [<title>] tag
   @override
-  String get title => document?.head?.querySelector('title')?.text;
+  String get title => document?.head
+      ?.querySelector('title')
+      ?.text;
 
   /// Get the [Metadata.description] from the <meta name="description" content=""> tag
   @override
@@ -23,6 +25,12 @@ class HtmlMetaParser extends BaseMetadataParser {
 
   /// Get the [Metadata.image] from the first <img> tag in the body;s
   @override
-  String get image =>
-      document?.body?.querySelector('img')?.attributes?.get('src');
+  String get image =>  document?.body
+      ?.querySelector('img')
+      ?.attributes
+      ?.get('src');
+
+  /// Get the [Document.url] from the Document extension.
+  @override
+  String get url => document.requestUrl;
 }

--- a/lib/src/parsers/jsonld_parser.dart
+++ b/lib/src/parsers/jsonld_parser.dart
@@ -16,7 +16,7 @@ class JsonLdParser extends BaseMetadataParser {
   }
 
   dynamic _parseToJson(Document document) {
-    var data = document?.head
+    final data = document?.head
         ?.querySelector("script[type='application/ld+json']")
         ?.innerHtml;
     if (data == null) {
@@ -29,7 +29,7 @@ class JsonLdParser extends BaseMetadataParser {
   /// Get the [Metadata.title] from the [<title>] tag
   @override
   String get title {
-    var data = _jsonData;
+    final data = _jsonData;
     if (data is List) {
       return data?.first['name'];
     } else if (data is Map) {
@@ -41,7 +41,7 @@ class JsonLdParser extends BaseMetadataParser {
   /// Get the [Metadata.description] from the <meta name="description" content=""> tag
   @override
   String get description {
-    var data = _jsonData;
+    final data = _jsonData;
     if (data is List) {
       return data?.first['description'] ?? data?.first['headline'];
     } else if (data is Map) {
@@ -53,12 +53,16 @@ class JsonLdParser extends BaseMetadataParser {
   /// Get the [Metadata.image] from the first <img> tag in the body;s
   @override
   String get image {
-    var data = _jsonData;
+    final data = _jsonData;
     if (data is List) {
-      return data?.first['logo'] ?? data?.first['image']?.first;
+      return data?.first['logo'] ?? data?.first['image'];
     } else if (data is Map) {
       return data?.get('logo') ?? data['image'][0];
     }
     return null;
   }
+
+  /// Get the [Document.url] from the Document extension.
+  @override
+  String get url => document.requestUrl;
 }

--- a/lib/src/parsers/metadata_parser.dart
+++ b/lib/src/parsers/metadata_parser.dart
@@ -5,26 +5,29 @@ import 'package:metadata_fetch/metadata_fetch.dart';
 class MetadataParser {
   /// This is the default strategy for building our [Metadata]
   ///
-  /// It tries [OpenGraphParser], then [JsonLdParser], and falls back to [HTMLMetaParser] tags for missing data.
+  /// It tries [OpenGraphParser], then [TwitterCardParser], then [JsonLdParser], and falls back to [HTMLMetaParser] tags for missing data.
   static Metadata parse(Document document) {
-    var output = Metadata();
+    final output = Metadata();
 
-    var parsers = [
+    final parsers = [
       OpenGraph(document),
-      HtmlMeta(document),
+      TwitterCard(document),
       JsonLdSchema(document),
+      HtmlMeta(document),
     ];
 
     for (final p in parsers) {
       output.title ??= p.title;
       output.description ??= p.description;
       output.image ??= p.image;
+      output.url ??= p.url;
 
       // is there a cleaner way?
-      final hasEmpty = ((output.title == null ||
-              output.description == null ||
-              output.image == null) ==
-          true);
+      final hasEmpty = ((
+          output.title == null ||
+          output.description == null ||
+          output.image == null ||
+          output.url == null) == true);
 
       if (!hasEmpty) {
         break;
@@ -45,5 +48,9 @@ class MetadataParser {
 
   static Metadata JsonLdSchema(Document document) {
     return JsonLdParser(document).parse();
+  }
+
+  static Metadata TwitterCard(Document document) {
+    return TwitterCardParser(document).parse();
   }
 }

--- a/lib/src/parsers/opengraph_parser.dart
+++ b/lib/src/parsers/opengraph_parser.dart
@@ -5,27 +5,34 @@ import 'base_parser.dart';
 
 /// Takes a [http.Document] and parses [Metadata] from [<meta property='og:*'>] tags
 class OpenGraphParser extends BaseMetadataParser {
-  Document document;
-  OpenGraphParser(this.document);
+  final Document _document;
+  OpenGraphParser(this._document);
 
   /// Get [Metadata.title] from 'og:title'
   @override
-  String get title => document?.head
+  String get title => _document?.head
       ?.querySelector("[property*='og:title']")
       ?.attributes
       ?.get('content');
 
   /// Get [Metadata.description] from 'og:description'
   @override
-  String get description => document?.head
+  String get description => _document?.head
       ?.querySelector("[property*='og:description']")
       ?.attributes
       ?.get('content');
 
   /// Get [Metadata.image] from 'og:image'
   @override
-  String get image => document?.head
+  String get image => _document?.head
       ?.querySelector("[property*='og:image']")
+      ?.attributes
+      ?.get('content');
+
+  /// Get [Metadata.url] from 'og:url'
+  @override
+  String get url => _document?.head
+      ?.querySelector("[property*='og:url']")
       ?.attributes
       ?.get('content');
 }

--- a/lib/src/parsers/parsers.dart
+++ b/lib/src/parsers/parsers.dart
@@ -4,3 +4,4 @@ export 'metadata_parser.dart';
 export 'htmlmeta_parser.dart';
 export 'opengraph_parser.dart';
 export 'jsonld_parser.dart';
+export 'twittercard_parser.dart';

--- a/lib/src/parsers/twittercard_parser.dart
+++ b/lib/src/parsers/twittercard_parser.dart
@@ -1,0 +1,34 @@
+import 'package:html/dom.dart';
+import 'package:metadata_fetch/src/utils/util.dart';
+
+import 'base_parser.dart';
+
+/// Takes a [http.Document] and parses [Metadata] from [<meta property='twitter:*'>] tags
+class TwitterCardParser extends BaseMetadataParser {
+  Document document;
+  TwitterCardParser(this.document);
+
+  /// Get [Metadata.title] from 'twitter:title'
+  @override
+  String get title => document?.head
+      ?.querySelector("[property*='twitter:title']")
+      ?.attributes
+      ?.get('content');
+
+  /// Get [Metadata.description] from 'twitter:description'
+  @override
+  String get description => document?.head
+      ?.querySelector("[property*='twitter:description']")
+      ?.attributes
+      ?.get('content');
+
+  /// Get [Metadata.image] from 'twitter:image'
+  @override
+  String get image => document?.head
+      ?.querySelector("[property*='twitter:image']")
+      ?.attributes
+      ?.get('content');
+
+  /// Get [Document.url]
+  String get url => document.requestUrl;
+}

--- a/lib/src/utils/util.dart
+++ b/lib/src/utils/util.dart
@@ -1,7 +1,23 @@
+import 'package:html/dom.dart';
+
 extension GetMethod on Map {
   String get(dynamic Key) {
     return (this[Key]);
   }
+}
+
+/// Adds getter/setter for the original [Response.request.url]
+extension HttpRequestData on Document {
+  static String _requestUrl;
+
+  String get requestUrl {
+    return _requestUrl;
+  }
+
+  set requestUrl(String newValue) {
+    _requestUrl = newValue;
+  }
+
 }
 
 String getDomain(String url) {


### PR DESCRIPTION
### Changes & Additions
* Adds TwitterCardParser
* Adds extension 'HttpResponseData' on Document to persist the request URL by adding getter/setter for 'requestUrl'
* Extends 'BaseMetadataParser' by adding 'url' field
* Extends all existent parsers by adding a getter for 'url'
* repalces 'var' by 'final' where applicable

### Bugfixes
* Fixes a bug in JsonLdParser on requesting the 'image' tag