### PR TITLE
make json parser handle list of images

### DIFF
--- a/lib/src/parsers/jsonld_parser.dart
+++ b/lib/src/parsers/jsonld_parser.dart
@@ -54,11 +54,24 @@ class JsonLdParser with BaseMetadataParser {
   @override
   String get image {
     final data = _jsonData;
-    if (data is List) {
-      return data?.first['logo'] ?? data?.first['image'];
+    if (data is List && data.isNotEmpty) {
+      return _imageResultToString(data?.first['logo'] ?? data?.first['image']);
     } else if (data is Map) {
-      return data?.get('logo') ?? data?.get('image');
+      return _imageResultToString(data?.getDynamic('logo') ?? data?.getDynamic('image'));
     }
+
+    return null;
+  }
+
+  String _imageResultToString(dynamic result) {
+    if (result is List && result.isNotEmpty) {
+      result = result.first;
+    }
+
+    if (result is String) {
+      return result;
+    }
+
     return null;
   }
 

--- a/lib/src/utils/util.dart
+++ b/lib/src/utils/util.dart
@@ -4,6 +4,10 @@ extension GetMethod on Map {
   String get(dynamic Key) {
     return (this[Key]);
   }
+
+  dynamic getDynamic(dynamic Key) {
+    return (this[Key]);
+  }
 }
 
 /// Adds getter/setter for the original [Response.request.url]


### PR DESCRIPTION
Fixes a crash if the pages contains multiple images. Now takes the first image in that case.

```
I/flutter ( 4232): ERROR type 'List<dynamic>' is not a subtype of type 'String', #0      GetMethod.get (package:metadata_fetch/src/utils/util.dart:5:5)
I/flutter ( 4232): #1      JsonLdParser.image (package:metadata_fetch/src/parsers/jsonld_parser.dart:61:62)
I/flutter ( 4232): #2      BaseMetadataParser.parse (package:metadata_fetch/src/parsers/base_parser.dart:20:15)
I/flutter ( 4232): #3      MetadataParser.JsonLdSchema (package:metadata_fetch/src/parsers/metadata_parser.dart:42:35)
I/flutter ( 4232): #4      MetadataParser.parse (package:metadata_fetch/src/parsers/metadata_parser.dart:15:7)
I/flutter ( 4232): #5      _extractMetadata (package:metadata_fetch/src/metadata_fetch_base.dart:50:25)
I/flutter ( 4232): #6      extract (package:metadata_fetch/src/metadata_fetch_base.dart:24:16)
```