### PR TITLE
Fix image urls that don't start with a /

### DIFF
--- a/lib/src/parsers/metadata_parser.dart
+++ b/lib/src/parsers/metadata_parser.dart
@@ -35,6 +35,14 @@ class MetadataParser {
     if (imageLink == null) return null;
     if (imageLink.startsWith("http")) return imageLink;
     var pageUrl = Uri.parse(data.url);
+    if (!imageLink.startsWith("/")) {
+      // Some image srcs don't begin with a slash, so the image url ends up being
+      // weirdly mangled if it's just appended to the page host. Example:
+      // imageLink = "assets/someImg.png"
+      // http://example.comassets/someImg.png
+      // So this should fix that
+      imageLink = "/$imageLink";
+    }
     return pageUrl.scheme + "://" + pageUrl.host + imageLink;
   }
 

--- a/test/metadata_fetch_test.dart
+++ b/test/metadata_fetch_test.dart
@@ -159,5 +159,17 @@ void main() {
       var data = await extract('https://google');
       expect(data == null, true);
     });
+
+    test(
+        "Image url without slash at beginning still results in valid url when falling back to html parser",
+        () async {
+      // This test is extremely brittle, would be better to use a site that
+      // is more likely to always be available. Or better yet a custom
+      // document that will always cause this situation to happen
+      var data = await extract(
+          "https://underjord.io/live-server-push-without-js.html");
+      expect(data.image,
+          equals("https://underjord.io/assets/images/logotype.png"));
+    });
   });
 }


### PR DESCRIPTION
When a relative image url is used on a page, the html parser expects it to start with a /, but this isn't always the case, as can be seen on the site I used for the test ([link](https://underjord.io/live-server-push-without-js.html)). In order to fix this, I added a check to see if the image url begins with a / and add one to it if it doesn't have one.