### PR TITLE
Fix image relative URL resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.dart_tool/
+.packages
+pubspec.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.4
+
+- Fix resolution of relative URL for images
+
 ## 0.3.3
 
 - Relative image url now uses the absolute path

--- a/lib/src/parsers/metadata_parser.dart
+++ b/lib/src/parsers/metadata_parser.dart
@@ -19,7 +19,7 @@ class MetadataParser {
     for (final p in parsers) {
       output.title ??= p.title;
       output.description ??= p.description;
-      output.image ??= _imageUrl(p);
+      output.image ??= p.image;
       output.url ??= p.url;
 
       if (output.hasAllMetadata) {
@@ -27,23 +27,11 @@ class MetadataParser {
       }
     }
 
-    return output;
-  }
-
-  static String _imageUrl(Metadata data) {
-    String imageLink = data.image;
-    if (imageLink == null) return null;
-    if (imageLink.startsWith("http")) return imageLink;
-    var pageUrl = Uri.parse(data.url);
-    if (!imageLink.startsWith("/")) {
-      // Some image srcs don't begin with a slash, so the image url ends up being
-      // weirdly mangled if it's just appended to the page host. Example:
-      // imageLink = "assets/someImg.png"
-      // http://example.comassets/someImg.png
-      // So this should fix that
-      imageLink = "/$imageLink";
+    if (output.url != null && output.image != null) {
+      output.image = Uri.parse(output.url).resolve(output.image).toString();
     }
-    return pageUrl.scheme + "://" + pageUrl.host + imageLink;
+
+    return output;
   }
 
   static Metadata openGraph(Document document) {


### PR DESCRIPTION
The resolution of relative URLs in images is broken, as it is interpreting a relative URL that doesn't start with `/` as an absolute path:

base URL: https://example.com/path/to/page.html
image URL: image.png

-> https://example.com/image.png

This is wrong and it should be resolved to https://example.com/path/to/image.png instead. On top of that, other type of "relative" URLs, like "network-path references" (URLs omiting only the scheme, like "//example.com/image.png") are not handled at all.

Dart already provides URI resolution (Uri.resolve) as specified by RFC3986 (https://tools.ietf.org/html/rfc3986), so it is much more reliable to use that instead of rolling our own.

This commit also supports having a null base URL in the Metadata, in which case the image URL will simply not be resolved (the library client can perform their own resolution if needed). A new test case is added to make sure this doesn't break again.

Fixes #17.