### PR TITLE
Add readability by follow pedantic linter rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.dart_tool/
+.packages
+build/
+pubspec.lock

--- a/lib/src/metadata_fetch_base.dart
+++ b/lib/src/metadata_fetch_base.dart
@@ -21,9 +21,9 @@ Future<Metadata> extract(String url) async {
   // Make our network call
   final response = await http.get(url);
 
-  if (response.headers["content-type"].startsWith(r"image/")) {
-    defaultOutput.title = "";
-    defaultOutput.description = "";
+  if (response.headers['content-type'].startsWith(r'image/')) {
+    defaultOutput.title = '';
+    defaultOutput.description = '';
     defaultOutput.image = url;
     return defaultOutput;
   }

--- a/lib/src/parsers/base_parser.dart
+++ b/lib/src/parsers/base_parser.dart
@@ -27,13 +27,14 @@ mixin BaseMetadataParser {
 class Metadata with BaseMetadataParser, MetadataKeys {
   bool get hasAllMetadata {
     return (
-        this.title != null &&
-        this.description != null &&
-        this.image != null &&
-        this.url != null
+        title != null &&
+        description != null &&
+        image != null &&
+        url != null
     );
   }
 
+  @override
   String toString() {
     return toMap().toString();
   }
@@ -51,7 +52,7 @@ class Metadata with BaseMetadataParser, MetadataKeys {
     return toMap();
   }
 
-  static fromJson(Map<String, dynamic> json) {
+  static Metadata fromJson(Map<String, dynamic> json) {
     final m = Metadata();
     m.title = json[MetadataKeys.keyTitle];
     m.description = json[MetadataKeys.keyDescription];

--- a/lib/src/parsers/htmlmeta_parser.dart
+++ b/lib/src/parsers/htmlmeta_parser.dart
@@ -18,8 +18,8 @@ class HtmlMetaParser with BaseMetadataParser {
   @override
   String get description => getProperty(
         _document,
-        attribute: "name",
-        property: "og:url",
+        attribute: 'name',
+        property: 'og:url',
       );
 
   /// Get the [Metadata.image] from the first <img> tag in the body;s
@@ -32,5 +32,5 @@ class HtmlMetaParser with BaseMetadataParser {
   String get url => _document?.requestUrl;
 
   @override
-  String toString() => this.parse().toString();
+  String toString() => parse().toString();
 }

--- a/lib/src/parsers/jsonld_parser.dart
+++ b/lib/src/parsers/jsonld_parser.dart
@@ -81,5 +81,5 @@ class JsonLdParser with BaseMetadataParser {
   String get url => document?.requestUrl;
 
   @override
-  String toString() => this.parse().toString();
+  String toString() => parse().toString();
 }

--- a/lib/src/parsers/metadata_parser.dart
+++ b/lib/src/parsers/metadata_parser.dart
@@ -31,19 +31,19 @@ class MetadataParser {
   }
 
   static String _imageUrl(Metadata data) {
-    String imageLink = data.image;
+    var imageLink = data.image;
     if (imageLink == null) return null;
-    if (imageLink.startsWith("http")) return imageLink;
+    if (imageLink.startsWith('http')) return imageLink;
     var pageUrl = Uri.parse(data.url);
-    if (!imageLink.startsWith("/")) {
+    if (!imageLink.startsWith('/')) {
       // Some image srcs don't begin with a slash, so the image url ends up being
       // weirdly mangled if it's just appended to the page host. Example:
       // imageLink = "assets/someImg.png"
       // http://example.comassets/someImg.png
       // So this should fix that
-      imageLink = "/$imageLink";
+      imageLink = '/$imageLink';
     }
-    return pageUrl.scheme + "://" + pageUrl.host + imageLink;
+    return pageUrl.scheme + '://' + pageUrl.host + imageLink;
   }
 
   static Metadata openGraph(Document document) {

--- a/lib/src/parsers/opengraph_parser.dart
+++ b/lib/src/parsers/opengraph_parser.dart
@@ -12,30 +12,30 @@ class OpenGraphParser with BaseMetadataParser {
   @override
   String get title => getProperty(
         _document,
-        property: "og:title",
+        property: 'og:title',
       );
 
   /// Get [Metadata.description] from 'og:description'
   @override
   String get description => getProperty(
         _document,
-        property: "og:description",
+        property: 'og:description',
       );
 
   /// Get [Metadata.image] from 'og:image'
   @override
   String get image => getProperty(
         _document,
-        property: "og:image",
+        property: 'og:image',
       );
 
   /// Get [Metadata.url] from 'og:url'
   @override
   String get url => getProperty(
         _document,
-        property: "og:url",
+        property: 'og:url',
       );
 
   @override
-  String toString() => this.parse().toString();
+  String toString() => parse().toString();
 }

--- a/lib/src/parsers/twittercard_parser.dart
+++ b/lib/src/parsers/twittercard_parser.dart
@@ -13,12 +13,12 @@ class TwitterCardParser with BaseMetadataParser {
   String get title =>
       getProperty(
         _document,
-        attribute: "name",
-        property: "twitter:title",
+        attribute: 'name',
+        property: 'twitter:title',
       ) ??
       getProperty(
         _document,
-        property: "twitter:title",
+        property: 'twitter:title',
       );
 
   /// Get [Metadata.description] from 'twitter:description'
@@ -26,12 +26,12 @@ class TwitterCardParser with BaseMetadataParser {
   String get description =>
       getProperty(
         _document,
-        attribute: "name",
-        property: "twitter:description",
+        attribute: 'name',
+        property: 'twitter:description',
       ) ??
       getProperty(
         _document,
-        property: "twitter:description",
+        property: 'twitter:description',
       );
 
   /// Get [Metadata.image] from 'twitter:image'
@@ -39,17 +39,18 @@ class TwitterCardParser with BaseMetadataParser {
   String get image =>
       getProperty(
         _document,
-        attribute: "name",
-        property: "twitter:image",
+        attribute: 'name',
+        property: 'twitter:image',
       ) ??
       getProperty(
         _document,
-        property: "twitter:image",
+        property: 'twitter:image',
       );
 
   /// Get [Document.url]
+  @override
   String get url => _document?.requestUrl;
 
   @override
-  String toString() => this.parse().toString();
+  String toString() => parse().toString();
 }

--- a/lib/src/utils/util.dart
+++ b/lib/src/utils/util.dart
@@ -31,10 +31,10 @@ String getDomain(String url) {
 
 String getProperty(
   Document document, {
-  String tag = "meta",
-  String attribute = "property",
+  String tag = 'meta',
+  String attribute = 'property',
   String property,
-  String key = "content",
+  String key = 'content',
 }) {
   return document
       ?.getElementsByTagName(tag)

--- a/test/metadata_fetch_test.dart
+++ b/test/metadata_fetch_test.dart
@@ -161,15 +161,15 @@ void main() {
     });
 
     test(
-        "Image url without slash at beginning still results in valid url when falling back to html parser",
+        'Image url without slash at beginning still results in valid url when falling back to html parser',
         () async {
       // This test is extremely brittle, would be better to use a site that
       // is more likely to always be available. Or better yet a custom
       // document that will always cause this situation to happen
       var data = await extract(
-          "https://underjord.io/live-server-push-without-js.html");
+          'https://underjord.io/live-server-push-without-js.html');
       expect(data.image,
-          equals("https://underjord.io/assets/images/logotype.png"));
+          equals('https://underjord.io/assets/images/logotype.png'));
     });
   });
 }


### PR DESCRIPTION
I saw pendantic in dev_dependencies, but most of the code does not follow lint rules. Missing overrides annotations, unnecessary uses of this reference. I removed about 47 warnings from the code. My intention is to improve the readability of the code. I also added a .gitignore. I hope that this changes makes the code more readable, and more easier to collaborate.