### PR TITLE
Migrate to Dart sound null safety

### DIFF
--- a/example/basic_extract.dart
+++ b/example/basic_extract.dart
@@ -3,7 +3,7 @@ import 'package:metadata_fetch/metadata_fetch.dart';
 void main() async {
   var data = await extract('https://flutter.dev'); // returns a Metadata object
   print(data); // Metadata.toString()
-  print(data.title); // Metadata.title
-  print(data.toMap()); // converts Metadata to map
-  print(data.toJson()); // converts Metadata to JSON
+  print(data?.title); // Metadata.title
+  print(data?.toMap()); // converts Metadata to map
+  print(data?.toJson()); // converts Metadata to JSON
 }

--- a/example/parse_document.dart
+++ b/example/parse_document.dart
@@ -3,7 +3,7 @@ import 'package:http/http.dart' as http;
 
 void main() async {
   var url = 'https://flutter.dev';
-  var response = await http.get(url);
+  var response = await http.get(Uri.parse(url));
   var document = responseToDocument(response);
 
   var data = MetadataParser.parse(document);

--- a/lib/src/parsers/base_parser.dart
+++ b/lib/src/parsers/base_parser.dart
@@ -8,10 +8,10 @@ mixin MetadataKeys {
 }
 
 mixin BaseMetadataParser {
-  String title;
-  String description;
-  String image;
-  String url;
+  String? title;
+  String? description;
+  String? image;
+  String? url;
 
   Metadata parse() {
     final m = Metadata();
@@ -26,12 +26,10 @@ mixin BaseMetadataParser {
 /// Container class for Metadata
 class Metadata with BaseMetadataParser, MetadataKeys {
   bool get hasAllMetadata {
-    return (
-        title != null &&
+    return (title != null &&
         description != null &&
         image != null &&
-        url != null
-    );
+        url != null);
   }
 
   @override
@@ -39,7 +37,7 @@ class Metadata with BaseMetadataParser, MetadataKeys {
     return toMap().toString();
   }
 
-  Map<String, String> toMap() {
+  Map<String, String?> toMap() {
     return {
       MetadataKeys.keyTitle: title,
       MetadataKeys.keyDescription: description,

--- a/lib/src/parsers/htmlmeta_parser.dart
+++ b/lib/src/parsers/htmlmeta_parser.dart
@@ -6,17 +6,17 @@ import 'base_parser.dart';
 /// Takes a [http.document] and parses [Metadata] from [<meta>, <title>, <img>] tags
 class HtmlMetaParser with BaseMetadataParser {
   /// The [document] to be parse
-  final Document _document;
+  final Document? _document;
 
   HtmlMetaParser(this._document);
 
   /// Get the [Metadata.title] from the [<title>] tag
   @override
-  String get title => _document?.head?.querySelector('title')?.text;
+  String? get title => _document?.head?.querySelector('title')?.text;
 
   /// Get the [Metadata.description] from the <meta name="description" content=""> tag
   @override
-  String get description => getProperty(
+  String? get description => getProperty(
         _document,
         attribute: 'name',
         property: 'og:url',
@@ -24,12 +24,12 @@ class HtmlMetaParser with BaseMetadataParser {
 
   /// Get the [Metadata.image] from the first <img> tag in the body;s
   @override
-  String get image =>
-      _document?.body?.querySelector('img')?.attributes?.get('src');
+  String? get image =>
+      _document?.body?.querySelector('img')?.attributes.get('src');
 
   /// Get the [Document.url] from the Document extension.
   @override
-  String get url => _document?.requestUrl;
+  String? get url => _document?.requestUrl;
 
   @override
   String toString() => parse().toString();

--- a/lib/src/parsers/jsonld_parser.dart
+++ b/lib/src/parsers/jsonld_parser.dart
@@ -8,14 +8,14 @@ import 'base_parser.dart';
 /// Takes a [http.document] and parses [Metadata] from `json-ld` data in `<script>`
 class JsonLdParser with BaseMetadataParser {
   /// The [document] to be parse
-  Document document;
+  Document? document;
   dynamic _jsonData;
 
   JsonLdParser(this.document) {
     _jsonData = _parseToJson(document);
   }
 
-  dynamic _parseToJson(Document document) {
+  dynamic _parseToJson(Document? document) {
     final data = document?.head
         ?.querySelector("script[type='application/ld+json']")
         ?.innerHtml;
@@ -28,43 +28,43 @@ class JsonLdParser with BaseMetadataParser {
 
   /// Get the [Metadata.title] from the [<title>] tag
   @override
-  String get title {
+  String? get title {
     final data = _jsonData;
     if (data is List) {
-      return data?.first['name'];
+      return data.first['name'];
     } else if (data is Map) {
-      return data?.get('name') ?? data?.get('headline');
+      return data.get('name') ?? data.get('headline');
     }
     return null;
   }
 
   /// Get the [Metadata.description] from the <meta name="description" content=""> tag
   @override
-  String get description {
+  String? get description {
     final data = _jsonData;
     if (data is List) {
-      return data?.first['description'] ?? data?.first['headline'];
+      return data.first['description'] ?? data.first['headline'];
     } else if (data is Map) {
-      return data?.get('description') ?? data?.get('headline');
+      return data.get('description') ?? data.get('headline');
     }
     return null;
   }
 
   /// Get the [Metadata.image] from the first <img> tag in the body;s
   @override
-  String get image {
+  String? get image {
     final data = _jsonData;
     if (data is List && data.isNotEmpty) {
-      return _imageResultToString(data?.first['logo'] ?? data?.first['image']);
+      return _imageResultToString(data.first['logo'] ?? data.first['image']);
     } else if (data is Map) {
       return _imageResultToString(
-          data?.getDynamic('logo') ?? data?.getDynamic('image'));
+          data.getDynamic('logo') ?? data.getDynamic('image'));
     }
 
     return null;
   }
 
-  String _imageResultToString(dynamic result) {
+  String? _imageResultToString(dynamic result) {
     if (result is List && result.isNotEmpty) {
       result = result.first;
     }
@@ -78,7 +78,7 @@ class JsonLdParser with BaseMetadataParser {
 
   /// Get the document request URL from Document's [HttpRequestData] extension.
   @override
-  String get url => document?.requestUrl;
+  String? get url => document?.requestUrl;
 
   @override
   String toString() => parse().toString();

--- a/lib/src/parsers/metadata_parser.dart
+++ b/lib/src/parsers/metadata_parser.dart
@@ -6,7 +6,7 @@ class MetadataParser {
   /// This is the default strategy for building our [Metadata]
   ///
   /// It tries [OpenGraphParser], then [TwitterCardParser], then [JsonLdParser], and falls back to [HTMLMetaParser] tags for missing data.
-  static Metadata parse(Document document) {
+  static Metadata parse(Document? document) {
     final output = Metadata();
 
     final parsers = [
@@ -26,27 +26,28 @@ class MetadataParser {
         break;
       }
     }
-
-    if (output.url != null && output.image != null) {
-      output.image = Uri.parse(output.url).resolve(output.image).toString();
+    final url = output.url;
+    final image = output.image;
+    if (url != null && image != null) {
+      output.image = Uri.parse(url).resolve(image).toString();
     }
 
     return output;
   }
 
-  static Metadata openGraph(Document document) {
+  static Metadata openGraph(Document? document) {
     return OpenGraphParser(document).parse();
   }
 
-  static Metadata htmlMeta(Document document) {
+  static Metadata htmlMeta(Document? document) {
     return HtmlMetaParser(document).parse();
   }
 
-  static Metadata jsonLdSchema(Document document) {
+  static Metadata jsonLdSchema(Document? document) {
     return JsonLdParser(document).parse();
   }
 
-  static Metadata twitterCard(Document document) {
+  static Metadata twitterCard(Document? document) {
     return TwitterCardParser(document).parse();
   }
 }

--- a/lib/src/parsers/opengraph_parser.dart
+++ b/lib/src/parsers/opengraph_parser.dart
@@ -5,33 +5,33 @@ import 'base_parser.dart';
 
 /// Takes a [http.Document] and parses [Metadata] from [<meta property='og:*'>] tags
 class OpenGraphParser with BaseMetadataParser {
-  final Document _document;
+  final Document? _document;
   OpenGraphParser(this._document);
 
   /// Get [Metadata.title] from 'og:title'
   @override
-  String get title => getProperty(
+  String? get title => getProperty(
         _document,
         property: 'og:title',
       );
 
   /// Get [Metadata.description] from 'og:description'
   @override
-  String get description => getProperty(
+  String? get description => getProperty(
         _document,
         property: 'og:description',
       );
 
   /// Get [Metadata.image] from 'og:image'
   @override
-  String get image => getProperty(
+  String? get image => getProperty(
         _document,
         property: 'og:image',
       );
 
   /// Get [Metadata.url] from 'og:url'
   @override
-  String get url => getProperty(
+  String? get url => getProperty(
         _document,
         property: 'og:url',
       );

--- a/lib/src/parsers/twittercard_parser.dart
+++ b/lib/src/parsers/twittercard_parser.dart
@@ -5,12 +5,12 @@ import 'base_parser.dart';
 
 /// Takes a [http.Document] and parses [Metadata] from [<meta property='twitter:*'>] tags
 class TwitterCardParser with BaseMetadataParser {
-  final Document _document;
+  final Document? _document;
   TwitterCardParser(this._document);
 
   /// Get [Metadata.title] from 'twitter:title'
   @override
-  String get title =>
+  String? get title =>
       getProperty(
         _document,
         attribute: 'name',
@@ -23,7 +23,7 @@ class TwitterCardParser with BaseMetadataParser {
 
   /// Get [Metadata.description] from 'twitter:description'
   @override
-  String get description =>
+  String? get description =>
       getProperty(
         _document,
         attribute: 'name',
@@ -36,7 +36,7 @@ class TwitterCardParser with BaseMetadataParser {
 
   /// Get [Metadata.image] from 'twitter:image'
   @override
-  String get image =>
+  String? get image =>
       getProperty(
         _document,
         attribute: 'name',
@@ -49,7 +49,7 @@ class TwitterCardParser with BaseMetadataParser {
 
   /// Get [Document.url]
   @override
-  String get url => _document?.requestUrl;
+  String? get url => _document?.requestUrl;
 
   @override
   String toString() => parse().toString();

--- a/lib/src/utils/util.dart
+++ b/lib/src/utils/util.dart
@@ -1,7 +1,7 @@
 import 'package:html/dom.dart';
 
 extension GetMethod on Map {
-  String get(dynamic key) {
+  String? get(dynamic key) {
     var value = this[key];
     if (value is List) return value.first;
     return value.toString();
@@ -14,34 +14,33 @@ extension GetMethod on Map {
 
 /// Adds getter/setter for the original [Response.request.url]
 extension HttpRequestData on Document {
-  static String _requestUrl;
+  static String? _requestUrl;
 
-  String get requestUrl {
+  String? get requestUrl {
     return _requestUrl;
   }
 
-  set requestUrl(String newValue) {
+  set requestUrl(String? newValue) {
     _requestUrl = newValue;
   }
 }
 
-String getDomain(String url) {
-  return Uri.parse(url)?.host.toString().split('.')[0];
+String? getDomain(String url) {
+  return Uri.parse(url).host.toString().split('.')[0];
 }
 
-String getProperty(
-  Document document, {
+String? getProperty(
+  Document? document, {
   String tag = 'meta',
   String attribute = 'property',
-  String property,
+  String? property,
   String key = 'content',
 }) {
   return document
       ?.getElementsByTagName(tag)
-      ?.firstWhere(
-        (element) => element.attributes[attribute] == property,
-        orElse: () => null,
-      )
-      ?.attributes
-      ?.get(key);
+      .firstWhere((element) => element.attributes[attribute] == property,
+          orElse: () => Element.tag(tag) // FIXME: Cannot return null here
+          )
+      .attributes
+      .get(key);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,16 @@
 name: metadata_fetch
 description: A dart library for extracting metadata on web pages such as OpenGraph, Meta, Twitter Cards, and Structured Data (Json-LD)
-version: 0.3.4
+version: 0.4.0-nullsafety.0
 homepage: https://github.com/jg-l/metadata_fetch
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  http: ^0.12.0+4
-  string_validator: ^0.1.3
-  html: ^0.14.0+3
+  http: ^0.13.0-nullsafety.0
+  string_validator: ^0.2.0-nullsafety.0
+  html: ^0.15.0-nullsafety.0
 
 dev_dependencies:
-  pedantic: ^1.8.0
-  test: ^1.6.0
+  pedantic: ^1.10.0-nullsafety.3
+  test: ^1.16.0-nullsafety.17

--- a/test/metadata_fetch_test.dart
+++ b/test/metadata_fetch_test.dart
@@ -11,7 +11,7 @@ import 'package:test/test.dart';
 void main() {
   test('JSON Serialization', () async {
     var url = 'https://flutter.dev';
-    var response = await http.get(url);
+    var response = await http.get(Uri.parse(url));
     var document = responseToDocument(response);
     var data = MetadataParser.parse(document);
     print(data.toJson());
@@ -20,7 +20,7 @@ void main() {
 
   test('Metadata Parser', () async {
     var url = 'https://flutter.dev';
-    var response = await http.get(url);
+    var response = await http.get(Uri.parse(url));
     var document = responseToDocument(response);
 
     var data = MetadataParser.parse(document);
@@ -44,7 +44,7 @@ void main() {
   group('Metadata parsers', () {
     test('JSONLD', () async {
       var url = 'https://www.epicurious.com/';
-      var response = await http.get(url);
+      var response = await http.get(Uri.parse(url));
       var document = responseToDocument(response);
       // print(response.statusCode);
 
@@ -54,7 +54,7 @@ void main() {
     test('JSONLD II', () async {
       var url =
           'https://www.epicurious.com/expert-advice/best-soy-sauce-chefs-pick-article';
-      var response = await http.get(url);
+      var response = await http.get(Uri.parse(url));
       var document = responseToDocument(response);
       // print(response.statusCode);
 
@@ -64,7 +64,7 @@ void main() {
     test('JSONLD III', () async {
       var url =
           'https://medium.com/@quicky316/install-flutter-sdk-on-windows-without-android-studio-102fdf567ce4';
-      var response = await http.get(url);
+      var response = await http.get(Uri.parse(url));
       var document = responseToDocument(response);
       // print(response.statusCode);
 
@@ -73,7 +73,7 @@ void main() {
 
     test('JSONLD IV', () async {
       var url = 'https://www.distilled.net/';
-      var response = await http.get(url);
+      var response = await http.get(Uri.parse(url));
       var document = responseToDocument(response);
       // print(response.statusCode);
 
@@ -81,7 +81,7 @@ void main() {
     });
     test('HTML', () async {
       var url = 'https://flutter.dev';
-      var response = await http.get(url);
+      var response = await http.get(Uri.parse(url));
       var document = responseToDocument(response);
       print(response.statusCode);
 
@@ -92,7 +92,7 @@ void main() {
 
     test('OpenGraph Parser', () async {
       var url = 'https://flutter.dev';
-      var response = await http.get(url);
+      var response = await http.get(Uri.parse(url));
       var document = responseToDocument(response);
       print(response.statusCode);
 
@@ -104,19 +104,20 @@ void main() {
 
     test('OpenGraph Youtube Test', () async {
       String url = 'https://www.youtube.com/watch?v=0jz0GAFNNIo';
-      var response = await http.get(url);
+      var response = await http.get(Uri.parse(url));
       var document = responseToDocument(response);
       print(OpenGraphParser(document));
       print(OpenGraphParser(document).title);
       Metadata data = OpenGraphParser(document).parse();
       expect(data.title, 'Drake - When To Say When & Chicago Freestyle');
-      expect(data.image, 'https://i.ytimg.com/vi/0jz0GAFNNIo/maxresdefault.jpg');
+      expect(
+          data.image, 'https://i.ytimg.com/vi/0jz0GAFNNIo/maxresdefault.jpg');
     });
 
     test('TwitterCard Parser', () async {
       var url =
           'https://www.epicurious.com/expert-advice/best-soy-sauce-chefs-pick-article';
-      var response = await http.get(url);
+      var response = await http.get(Uri.parse(url));
       var document = responseToDocument(response);
       print(response.statusCode);
 
@@ -130,7 +131,7 @@ void main() {
 
     test('Faulty', () async {
       var url = 'https://google.ca';
-      var response = await http.get(url);
+      var response = await http.get(Uri.parse(url));
       var document = responseToDocument(response);
       print(response.statusCode);
 
@@ -148,37 +149,38 @@ void main() {
     test('First Test', () async {
       var data = await extract('https://flutter.dev/');
       print(data);
-      print(data.description);
-      expect(data.toMap().isEmpty, false);
+      print(data?.description);
+      expect(data?.toMap().isEmpty, false);
     });
 
     test('FB Test', () async {
       var data = await extract('https://facebook.com/');
-      expect(data.toMap().isEmpty, false);
+      expect(data?.toMap().isEmpty, false);
     });
 
     test('Youtube Test', () async {
-      Metadata data = await extract('https://www.youtube.com/watch?v=0jz0GAFNNIo');
-      expect(data.title, 'Drake - When To Say When & Chicago Freestyle');
-      expect(data.image, 'https://i.ytimg.com/vi/0jz0GAFNNIo/maxresdefault.jpg');
+      Metadata? data =
+          await extract('https://www.youtube.com/watch?v=0jz0GAFNNIo');
+      expect(data?.title, 'Drake - When To Say When & Chicago Freestyle');
+      expect(
+          data?.image, 'https://i.ytimg.com/vi/0jz0GAFNNIo/maxresdefault.jpg');
     });
 
     test('Unicode Test', () async {
       var data = await extract('https://www.jpf.go.jp/');
-      expect(data.toMap().isEmpty, false);
+      expect(data?.toMap().isEmpty, false);
     });
 
     test('Gooogle Test', () async {
       var data = await extract('https://google.ca');
-      expect(data.toMap().isEmpty, false);
-      expect(data.title, 'google');
+      expect(data?.toMap().isEmpty, false);
+      expect(data?.title, 'google');
     });
 
     test('Invalid Url Test', () async {
       var data = await extract('https://google');
       expect(data == null, true);
     });
-
 
     final htmlPage = '''
 <html>


### PR DESCRIPTION
Hello, we know that dart sound null safety feature is coming to stable channel. I was waiting for this package dependencies migrate to it. And these days was possible to migrate. See the changes in `pubspec.yaml`.

I ran the tests, but two tests has failed:
_"Image url without slash at beginning still results in valid url when falling back to html parser"_ and
_"MetadataParser.parse(doc) works without a doc.requestUrl (relative URLs are just not resolved)"_

I was not able to figure out why this fails, but I don't understand these tests purposes (sorry).
Well, this is my collaboration, since this package is very useful for me and other people.

