### PR TITLE
feat!(null-safety): switch to use NNBD sound null safety

### DIFF
--- a/example/basic_extract.dart
+++ b/example/basic_extract.dart
@@ -3,7 +3,7 @@ import 'package:metadata_fetch/metadata_fetch.dart';
 void main() async {
   var data = await extract('https://flutter.dev'); // returns a Metadata object
   print(data); // Metadata.toString()
-  print(data.title); // Metadata.title
+  print(data!.title); // Metadata.title
   print(data.toMap()); // converts Metadata to map
   print(data.toJson()); // converts Metadata to JSON
 }

--- a/example/parse_document.dart
+++ b/example/parse_document.dart
@@ -3,7 +3,7 @@ import 'package:http/http.dart' as http;
 
 void main() async {
   var url = 'https://flutter.dev';
-  var response = await http.get(url);
+  var response = await http.get(Uri.parse(url));
   var document = responseToDocument(response);
 
   var data = MetadataParser.parse(document);

--- a/lib/src/metadata_fetch_base.dart
+++ b/lib/src/metadata_fetch_base.dart
@@ -8,7 +8,7 @@ import 'package:metadata_fetch/src/utils/util.dart';
 import 'package:string_validator/string_validator.dart';
 
 /// Fetches a [url], validates it, and returns [Metadata].
-Future<Metadata> extract(String url) async {
+Future<Metadata?> extract(String url) async {
   if (!isURL(url)) {
     return null;
   }
@@ -19,9 +19,9 @@ Future<Metadata> extract(String url) async {
   defaultOutput.description = url;
 
   // Make our network call
-  final response = await http.get(url);
+  final response = await http.get(Uri.parse(url));
 
-  if (response.headers['content-type'].startsWith(r'image/')) {
+  if (response.headers['content-type']?.startsWith(r'image/') ?? false) {
     defaultOutput.title = '';
     defaultOutput.description = '';
     defaultOutput.image = url;
@@ -34,24 +34,21 @@ Future<Metadata> extract(String url) async {
     return defaultOutput;
   }
 
-  final data = _extractMetadata(document);
-  if (data == null) {
-    return defaultOutput;
-  }
-
-  return data;
+  return _extractMetadata(document);
 }
 
 /// Takes an [http.Response] and returns a [html.Document]
-Document responseToDocument(http.Response response) {
+Document? responseToDocument(http.Response response) {
   if (response.statusCode != 200) {
     return null;
   }
 
-  Document document;
+  Document? document;
   try {
     document = parser.parse(utf8.decode(response.bodyBytes));
-    document.requestUrl = response.request.url.toString();
+    if (response.request != null) {
+      document.requestUrl = response.request!.url.toString();
+    }
   } catch (err) {
     return document;
   }

--- a/lib/src/parsers/base_parser.dart
+++ b/lib/src/parsers/base_parser.dart
@@ -8,10 +8,10 @@ mixin MetadataKeys {
 }
 
 mixin BaseMetadataParser {
-  String title;
-  String description;
-  String image;
-  String url;
+  String? title;
+  String? description;
+  String? image;
+  String? url;
 
   Metadata parse() {
     final m = Metadata();
@@ -39,7 +39,7 @@ class Metadata with BaseMetadataParser, MetadataKeys {
     return toMap().toString();
   }
 
-  Map<String, String> toMap() {
+  Map<String, String?> toMap() {
     return {
       MetadataKeys.keyTitle: title,
       MetadataKeys.keyDescription: description,

--- a/lib/src/parsers/htmlmeta_parser.dart
+++ b/lib/src/parsers/htmlmeta_parser.dart
@@ -6,17 +6,17 @@ import 'base_parser.dart';
 /// Takes a [http.document] and parses [Metadata] from [<meta>, <title>, <img>] tags
 class HtmlMetaParser with BaseMetadataParser {
   /// The [document] to be parse
-  final Document _document;
+  final Document? _document;
 
   HtmlMetaParser(this._document);
 
   /// Get the [Metadata.title] from the [<title>] tag
   @override
-  String get title => _document?.head?.querySelector('title')?.text;
+  String? get title => _document?.head?.querySelector('title')?.text;
 
   /// Get the [Metadata.description] from the <meta name="description" content=""> tag
   @override
-  String get description => getProperty(
+  String? get description => getProperty(
         _document,
         attribute: 'name',
         property: 'og:url',
@@ -24,12 +24,12 @@ class HtmlMetaParser with BaseMetadataParser {
 
   /// Get the [Metadata.image] from the first <img> tag in the body;s
   @override
-  String get image =>
-      _document?.body?.querySelector('img')?.attributes?.get('src');
+  String? get image =>
+      _document?.body?.querySelector('img')?.attributes.get('src');
 
   /// Get the [Document.url] from the Document extension.
   @override
-  String get url => _document?.requestUrl;
+  String? get url => _document?.requestUrl;
 
   @override
   String toString() => parse().toString();

--- a/lib/src/parsers/jsonld_parser.dart
+++ b/lib/src/parsers/jsonld_parser.dart
@@ -8,17 +8,15 @@ import 'base_parser.dart';
 /// Takes a [http.document] and parses [Metadata] from `json-ld` data in `<script>`
 class JsonLdParser with BaseMetadataParser {
   /// The [document] to be parse
-  Document document;
-  dynamic _jsonData;
+  Document? document;
+  dynamic? _jsonData;
 
   JsonLdParser(this.document) {
     _jsonData = _parseToJson(document);
   }
 
-  dynamic _parseToJson(Document document) {
-    final data = document?.head
-        ?.querySelector("script[type='application/ld+json']")
-        ?.innerHtml;
+  dynamic? _parseToJson(Document? document) {
+    final data = document?.head?.querySelector("script[type='application/ld+json']")?.innerHtml;
     if (data == null) {
       return null;
     }
@@ -28,43 +26,42 @@ class JsonLdParser with BaseMetadataParser {
 
   /// Get the [Metadata.title] from the [<title>] tag
   @override
-  String get title {
+  String? get title {
     final data = _jsonData;
     if (data is List) {
-      return data?.first['name'];
+      return data.first['name'];
     } else if (data is Map) {
-      return data?.get('name') ?? data?.get('headline');
+      return data.get('name') ?? data.get('headline');
     }
     return null;
   }
 
   /// Get the [Metadata.description] from the <meta name="description" content=""> tag
   @override
-  String get description {
+  String? get description {
     final data = _jsonData;
     if (data is List) {
-      return data?.first['description'] ?? data?.first['headline'];
+      return data.first['description'] ?? data.first['headline'];
     } else if (data is Map) {
-      return data?.get('description') ?? data?.get('headline');
+      return data.get('description') ?? data.get('headline');
     }
     return null;
   }
 
   /// Get the [Metadata.image] from the first <img> tag in the body;s
   @override
-  String get image {
+  String? get image {
     final data = _jsonData;
     if (data is List && data.isNotEmpty) {
-      return _imageResultToString(data?.first['logo'] ?? data?.first['image']);
+      return _imageResultToString(data.first['logo'] ?? data.first['image']);
     } else if (data is Map) {
-      return _imageResultToString(
-          data?.getDynamic('logo') ?? data?.getDynamic('image'));
+      return _imageResultToString(data.getDynamic('logo') ?? data.getDynamic('image'));
     }
 
     return null;
   }
 
-  String _imageResultToString(dynamic result) {
+  String? _imageResultToString(dynamic result) {
     if (result is List && result.isNotEmpty) {
       result = result.first;
     }
@@ -78,7 +75,7 @@ class JsonLdParser with BaseMetadataParser {
 
   /// Get the document request URL from Document's [HttpRequestData] extension.
   @override
-  String get url => document?.requestUrl;
+  String? get url => document.requestUrl;
 
   @override
   String toString() => parse().toString();

--- a/lib/src/parsers/metadata_parser.dart
+++ b/lib/src/parsers/metadata_parser.dart
@@ -6,7 +6,7 @@ class MetadataParser {
   /// This is the default strategy for building our [Metadata]
   ///
   /// It tries [OpenGraphParser], then [TwitterCardParser], then [JsonLdParser], and falls back to [HTMLMetaParser] tags for missing data.
-  static Metadata parse(Document document) {
+  static Metadata parse(Document? document) {
     final output = Metadata();
 
     final parsers = [
@@ -28,25 +28,25 @@ class MetadataParser {
     }
 
     if (output.url != null && output.image != null) {
-      output.image = Uri.parse(output.url).resolve(output.image).toString();
+      output.image = Uri.parse(output.url!).resolve(output.image!).toString();
     }
 
     return output;
   }
 
-  static Metadata openGraph(Document document) {
+  static Metadata openGraph(Document? document) {
     return OpenGraphParser(document).parse();
   }
 
-  static Metadata htmlMeta(Document document) {
+  static Metadata htmlMeta(Document? document) {
     return HtmlMetaParser(document).parse();
   }
 
-  static Metadata jsonLdSchema(Document document) {
+  static Metadata jsonLdSchema(Document? document) {
     return JsonLdParser(document).parse();
   }
 
-  static Metadata twitterCard(Document document) {
+  static Metadata twitterCard(Document? document) {
     return TwitterCardParser(document).parse();
   }
 }

--- a/lib/src/parsers/opengraph_parser.dart
+++ b/lib/src/parsers/opengraph_parser.dart
@@ -5,33 +5,33 @@ import 'base_parser.dart';
 
 /// Takes a [http.Document] and parses [Metadata] from [<meta property='og:*'>] tags
 class OpenGraphParser with BaseMetadataParser {
-  final Document _document;
+  final Document? _document;
   OpenGraphParser(this._document);
 
   /// Get [Metadata.title] from 'og:title'
   @override
-  String get title => getProperty(
+  String? get title => getProperty(
         _document,
         property: 'og:title',
       );
 
   /// Get [Metadata.description] from 'og:description'
   @override
-  String get description => getProperty(
+  String? get description => getProperty(
         _document,
         property: 'og:description',
       );
 
   /// Get [Metadata.image] from 'og:image'
   @override
-  String get image => getProperty(
+  String? get image => getProperty(
         _document,
         property: 'og:image',
       );
 
   /// Get [Metadata.url] from 'og:url'
   @override
-  String get url => getProperty(
+  String? get url => getProperty(
         _document,
         property: 'og:url',
       );

--- a/lib/src/parsers/twittercard_parser.dart
+++ b/lib/src/parsers/twittercard_parser.dart
@@ -5,12 +5,12 @@ import 'base_parser.dart';
 
 /// Takes a [http.Document] and parses [Metadata] from [<meta property='twitter:*'>] tags
 class TwitterCardParser with BaseMetadataParser {
-  final Document _document;
+  final Document? _document;
   TwitterCardParser(this._document);
 
   /// Get [Metadata.title] from 'twitter:title'
   @override
-  String get title =>
+  String? get title =>
       getProperty(
         _document,
         attribute: 'name',
@@ -23,7 +23,7 @@ class TwitterCardParser with BaseMetadataParser {
 
   /// Get [Metadata.description] from 'twitter:description'
   @override
-  String get description =>
+  String? get description =>
       getProperty(
         _document,
         attribute: 'name',
@@ -36,7 +36,7 @@ class TwitterCardParser with BaseMetadataParser {
 
   /// Get [Metadata.image] from 'twitter:image'
   @override
-  String get image =>
+  String? get image =>
       getProperty(
         _document,
         attribute: 'name',
@@ -49,7 +49,7 @@ class TwitterCardParser with BaseMetadataParser {
 
   /// Get [Document.url]
   @override
-  String get url => _document?.requestUrl;
+  String? get url => _document?.requestUrl;
 
   @override
   String toString() => parse().toString();

--- a/lib/src/utils/util.dart
+++ b/lib/src/utils/util.dart
@@ -1,10 +1,11 @@
+import 'package:collection/collection.dart' show IterableExtension;
 import 'package:html/dom.dart';
 
 extension GetMethod on Map {
-  String get(dynamic key) {
+  String? get(dynamic key) {
     var value = this[key];
     if (value is List) return value.first;
-    return value.toString();
+    return value?.toString();
   }
 
   dynamic getDynamic(dynamic key) {
@@ -13,35 +14,32 @@ extension GetMethod on Map {
 }
 
 /// Adds getter/setter for the original [Response.request.url]
-extension HttpRequestData on Document {
-  static String _requestUrl;
+extension HttpRequestData on Document? {
+  static String? _requestUrl;
 
-  String get requestUrl {
+  String? get requestUrl {
     return _requestUrl;
   }
 
-  set requestUrl(String newValue) {
+  set requestUrl(String? newValue) {
     _requestUrl = newValue;
   }
 }
 
 String getDomain(String url) {
-  return Uri.parse(url)?.host.toString().split('.')[0];
+  return Uri.parse(url).host.toString().split('.')[0];
 }
 
-String getProperty(
-  Document document, {
+String? getProperty(
+  Document? document, {
   String tag = 'meta',
   String attribute = 'property',
-  String property,
+  String? property,
   String key = 'content',
 }) {
   return document
       ?.getElementsByTagName(tag)
-      ?.firstWhere(
-        (element) => element.attributes[attribute] == property,
-        orElse: () => null,
-      )
+      .firstWhereOrNull((element) => element.attributes[attribute] == property)
       ?.attributes
-      ?.get(key);
+      .get(key);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,17 @@
 name: metadata_fetch
 description: A dart library for extracting metadata on web pages such as OpenGraph, Meta, Twitter Cards, and Structured Data (Json-LD)
-version: 0.3.4
+version: 1.0.0-nullsafety.0
 homepage: https://github.com/jg-l/metadata_fetch
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  http: ^0.12.0+4
-  string_validator: ^0.1.3
-  html: ^0.14.0+3
+  http: ^0.13.1
+  string_validator: ^0.3.0
+  html: ^0.15.0
+  collection: ^1.15.0-nullsafety.4
 
 dev_dependencies:
-  pedantic: ^1.8.0
-  test: ^1.6.0
+  pedantic: ^1.11.0
+  test: ^1.16.8

--- a/test/metadata_fetch_test.dart
+++ b/test/metadata_fetch_test.dart
@@ -11,174 +11,246 @@ import 'package:test/test.dart';
 void main() {
   test('JSON Serialization', () async {
     var url = 'https://flutter.dev';
-    var response = await http.get(url);
+    var response = await http.get(Uri.parse(url));
     var document = responseToDocument(response);
     var data = MetadataParser.parse(document);
-    print(data.toJson());
-    expect(data.toJson().isNotEmpty, true);
+    expect(data.toJson(), hasStringValue);
+    expect(data.title, hasStringValue);
+    expect(data.description, hasStringValue);
+    expect(data.url, hasStringValue);
+    expect(data.image, hasStringValue);
   });
 
-  test('Metadata Parser', () async {
+  group('Metadata Parser', () {
     var url = 'https://flutter.dev';
-    var response = await http.get(url);
-    var document = responseToDocument(response);
+    dynamic document;
 
-    var data = MetadataParser.parse(document);
-    print(data);
+    setUp(() async {
+      var response = await http.get(Uri.parse(url));
+      document = responseToDocument(response);
+    });
 
-    // Just Opengraph
-    var og = MetadataParser.openGraph(document);
-    print('OG $og');
+    test('parse', () {
+      var data = MetadataParser.parse(document);
+      expect(data.title, hasStringValue);
+      expect(data.description, hasStringValue);
+      expect(data.url, hasStringValue);
+      expect(data.image, hasStringValue);
+    });
 
-    // Just Html
-    var hm = MetadataParser.htmlMeta(document);
-    print('Html $hm');
+    test('openGraph', () {
+      // Just Opengraph
+      var og = MetadataParser.openGraph(document);
+      expect(og.title, hasStringValue);
+      expect(og.description, hasStringValue);
+      expect(og.url, hasStringValue);
+      expect(og.image, hasStringValue);
+    });
 
-    // Just Json-ld schema
-    var js = MetadataParser.jsonLdSchema(document);
-    print('JSON $js');
+    test('htmlMeta', () {
+      // Just Html
+      var hm = MetadataParser.htmlMeta(document);
+      expect(hm.title, hasStringValue);
+      expect(hm.description, isNull);
+      expect(hm.url, hasStringValue);
+      expect(hm.image, hasStringValue);
+    });
 
-    var twitter = MetadataParser.twitterCard(document);
-    print('Twitter $twitter');
+    test('jsonLdSchema', () {
+      // Just Json-ld schema
+      var js = MetadataParser.jsonLdSchema(document);
+      expect(js.title, isNull);
+      expect(js.description, isNull);
+      expect(js.url, hasStringValue);
+      expect(js.image, isNull);
+    });
+
+    test('twitterCard', () {
+      var twitter = MetadataParser.twitterCard(document);
+      expect(twitter.title, isNull);
+      expect(twitter.description, isNull);
+      expect(twitter.url, hasStringValue);
+      expect(twitter.image, isNull);
+    });
   });
+
   group('Metadata parsers', () {
     test('JSONLD', () async {
       var url = 'https://www.epicurious.com/';
-      var response = await http.get(url);
+      var response = await http.get(Uri.parse(url));
       var document = responseToDocument(response);
       // print(response.statusCode);
 
-      print(JsonLdParser(document));
+      final data = JsonLdParser(document);
+      expect(data.title, hasStringValue);
+      expect(data.description, hasStringValue);
+      expect(data.url, hasStringValue);
+      expect(data.image, isNull);
     });
 
     test('JSONLD II', () async {
-      var url =
-          'https://www.epicurious.com/expert-advice/best-soy-sauce-chefs-pick-article';
-      var response = await http.get(url);
+      var url = 'https://www.epicurious.com/expert-advice/best-soy-sauce-chefs-pick-article';
+      var response = await http.get(Uri.parse(url));
       var document = responseToDocument(response);
       // print(response.statusCode);
 
-      print(JsonLdParser(document));
+      final data = JsonLdParser(document);
+      expect(data.title, hasStringValue);
+      expect(data.description, hasStringValue);
+      expect(data.url, hasStringValue);
+      expect(data.image, hasStringValue);
     });
 
     test('JSONLD III', () async {
       var url =
           'https://medium.com/@quicky316/install-flutter-sdk-on-windows-without-android-studio-102fdf567ce4';
-      var response = await http.get(url);
+      var response = await http.get(Uri.parse(url));
       var document = responseToDocument(response);
       // print(response.statusCode);
 
-      print(JsonLdParser(document));
+      final data = JsonLdParser(document);
+      expect(data.title, hasStringValue);
+      expect(data.description, hasStringValue);
+      expect(data.url, hasStringValue);
+      expect(data.image, hasStringValue);
     });
 
     test('JSONLD IV', () async {
       var url = 'https://www.distilled.net/';
-      var response = await http.get(url);
+      var response = await http.get(Uri.parse(url));
       var document = responseToDocument(response);
       // print(response.statusCode);
 
-      print(JsonLdParser(document));
+      var data = JsonLdParser(document);
+      expect(data.title, hasStringValue);
+      expect(data.description, isNull);
+      expect(data.url, hasStringValue);
+      expect(data.image, hasStringValue);
     });
     test('HTML', () async {
       var url = 'https://flutter.dev';
-      var response = await http.get(url);
+      var response = await http.get(Uri.parse(url));
       var document = responseToDocument(response);
-      print(response.statusCode);
 
-      print(HtmlMetaParser(document).title);
-      print(HtmlMetaParser(document).description);
-      print(HtmlMetaParser(document).image);
+      final data = HtmlMetaParser(document);
+
+      expect(data.title, hasStringValue);
+      expect(data.description, isNull);
+      expect(data.url, hasStringValue);
+      expect(data.image, hasStringValue);
     });
 
     test('OpenGraph Parser', () async {
       var url = 'https://flutter.dev';
-      var response = await http.get(url);
+      var response = await http.get(Uri.parse(url));
       var document = responseToDocument(response);
-      print(response.statusCode);
 
-      print(OpenGraphParser(document));
-      print(OpenGraphParser(document).title);
-      print(OpenGraphParser(document).description);
-      print(OpenGraphParser(document).image);
+      var data = OpenGraphParser(document);
+      expect(data.title, hasStringValue);
+      expect(data.description, hasStringValue);
+      expect(data.url, hasStringValue);
+      expect(data.image, hasStringValue);
     });
 
     test('OpenGraph Youtube Test', () async {
       String url = 'https://www.youtube.com/watch?v=0jz0GAFNNIo';
-      var response = await http.get(url);
+      var response = await http.get(Uri.parse(url));
       var document = responseToDocument(response);
-      print(OpenGraphParser(document));
-      print(OpenGraphParser(document).title);
-      Metadata data = OpenGraphParser(document).parse();
+
+      final parser = OpenGraphParser(document);
+      expect(parser.title, hasStringValue);
+      expect(parser.description, hasStringValue);
+      expect(parser.url, hasStringValue);
+      expect(parser.image, hasStringValue);
+
+      Metadata data = parser.parse();
       expect(data.title, 'Drake - When To Say When & Chicago Freestyle');
       expect(data.image, 'https://i.ytimg.com/vi/0jz0GAFNNIo/maxresdefault.jpg');
+      expect(data.description, hasStringValue);
+      expect(data.url, hasStringValue);
     });
 
     test('TwitterCard Parser', () async {
-      var url =
-          'https://www.epicurious.com/expert-advice/best-soy-sauce-chefs-pick-article';
-      var response = await http.get(url);
+      var url = 'https://www.epicurious.com/expert-advice/best-soy-sauce-chefs-pick-article';
+      var response = await http.get(Uri.parse(url));
       var document = responseToDocument(response);
-      print(response.statusCode);
 
-      print(TwitterCardParser(document));
-      print(TwitterCardParser(document).title);
-      print(TwitterCardParser(document).description);
-      print(TwitterCardParser(document).image);
-      // Test the url
-      print(TwitterCardParser(document).url);
+      final data = TwitterCardParser(document);
+      expect(data.title, hasStringValue);
+      expect(data.description, hasStringValue);
+      expect(data.url, hasStringValue);
+      expect(data.image, isNull);
     });
 
     test('Faulty', () async {
       var url = 'https://google.ca';
-      var response = await http.get(url);
+      var response = await http.get(Uri.parse(url));
       var document = responseToDocument(response);
-      print(response.statusCode);
 
-      print(OpenGraphParser(document).title);
-      print(OpenGraphParser(document).description);
-      print(OpenGraphParser(document).image);
+      final og = OpenGraphParser(document);
+      expect(og.title, isNull);
+      expect(og.description, isNull);
+      expect(og.url, isNull);
+      expect(og.image, isNull);
 
-      print(HtmlMetaParser(document).title);
-      print(HtmlMetaParser(document).description);
-      print(HtmlMetaParser(document).image);
+      final hm = HtmlMetaParser(document);
+      expect(hm.title, isNull);
+      expect(hm.description, isNull);
+      expect(hm.url, isNull);
+      expect(hm.image, isNull);
     });
   });
 
   group('extract()', () {
     test('First Test', () async {
       var data = await extract('https://flutter.dev/');
-      print(data);
-      print(data.description);
-      expect(data.toMap().isEmpty, false);
+      expect(data!.toMap(), isNot(isEmpty));
+      expect(data.title, hasStringValue);
+      expect(data.description, hasStringValue);
+      expect(data.url, hasStringValue);
+      expect(data.image, hasStringValue);
     });
 
     test('FB Test', () async {
       var data = await extract('https://facebook.com/');
-      expect(data.toMap().isEmpty, false);
+      expect(data!.toMap(), isNot(isEmpty));
+      expect(data.title, hasStringValue);
+      expect(data.description, isNull);
+      expect(data.url, hasStringValue);
+      expect(data.image, hasStringValue);
     });
 
     test('Youtube Test', () async {
-      Metadata data = await extract('https://www.youtube.com/watch?v=0jz0GAFNNIo');
-      expect(data.title, 'Drake - When To Say When & Chicago Freestyle');
+      Metadata? data = await extract('https://www.youtube.com/watch?v=0jz0GAFNNIo');
+      expect(data!.title, 'Drake - When To Say When & Chicago Freestyle');
       expect(data.image, 'https://i.ytimg.com/vi/0jz0GAFNNIo/maxresdefault.jpg');
+
+      expect(data.description, hasStringValue);
+      expect(data.url, hasStringValue);
     });
 
     test('Unicode Test', () async {
       var data = await extract('https://www.jpf.go.jp/');
-      expect(data.toMap().isEmpty, false);
+      expect(data!.toMap(), isNot(isEmpty));
+      expect(data.title, hasStringValue);
+      expect(data.description, isNull);
+      expect(data.url, hasStringValue);
+      expect(data.image, hasStringValue);
     });
 
     test('Gooogle Test', () async {
       var data = await extract('https://google.ca');
-      expect(data.toMap().isEmpty, false);
+      expect(data!.toMap(), isNot(isEmpty));
       expect(data.title, 'google');
+      expect(data.description, hasStringValue);
+      expect(data.url, isNull);
+      expect(data.image, isNull);
     });
 
     test('Invalid Url Test', () async {
       var data = await extract('https://google');
       expect(data == null, true);
     });
-
 
     final htmlPage = '''
 <html>
@@ -198,6 +270,9 @@ void main() {
       doc.requestUrl = 'https://example.com/some/page.html';
       var data = MetadataParser.parse(doc);
       expect(data.image, equals('https://example.com/some/this/is/a/test.png'));
+      expect(data.title, 'Test');
+      expect(data.description, isNull);
+      expect(data.url, hasStringValue);
     });
 
     test(
@@ -210,6 +285,17 @@ void main() {
       doc.requestUrl = null;
       var data = MetadataParser.parse(doc);
       expect(data.image, equals('this/is/a/test.png'));
+      expect(data.title, 'Test');
+      expect(data.description, isNull);
+      expect(data.url, isNull);
     });
   });
 }
+
+class HasStringValue extends CustomMatcher {
+  HasStringValue()
+      : super('String is not empty or the value \'null\'', 'string',
+            allOf(isNotNull, isNotEmpty, isNot(contains('null'))));
+}
+
+final hasStringValue = HasStringValue();


### PR DESCRIPTION
- updated to latest null-safe deps and ran `dart migrate`
- fixed an issue where the map extension was returning the string 'null' instead of null values
- added assertions to tests to ensure results are at least populated when expected
- added tests and assertions for the 'null' string issue